### PR TITLE
fix: 修复通过ref调用对话框时，noCancelBtn属性无效的bug

### DIFF
--- a/packages/nutui/components/dialog/dialog.vue
+++ b/packages/nutui/components/dialog/dialog.vue
@@ -70,7 +70,7 @@ const { translate } = useTranslate(componentName)
         <slot v-if="$slots.footer" name="footer" />
         <template v-else>
           <NutButton
-            v-if="!noCancelBtn"
+            v-if="!dialogStatus.noCancelBtn"
             size="small"
             plain
             type="primary"


### PR DESCRIPTION
在使用ref方式调用对话框时，取消按钮无法通过noCancelBtn属性隐藏，条件渲染现已修改为：`v-if="!dialogStatus.noCancelBtn"` 