### PR TITLE
fix: (input) 修复左右插件默认文字无法显示

### DIFF
--- a/packages/nutui/components/input/index.scss
+++ b/packages/nutui/components/input/index.scss
@@ -119,7 +119,8 @@ textarea {
   &-right-box {
     display: flex;
     align-items: center;
-    font-size: 0;
+    
+    // font-size: 0;
   }
 
   &-right-box {


### PR DESCRIPTION
Fixes https://github.com/yang1206/uniapp-nutui/issues/21