### PR TITLE
fix: address组件未设置NutPopup的safe-area-inset-bottom

### DIFF
--- a/packages/nutui/components/address/address.vue
+++ b/packages/nutui/components/address/address.vue
@@ -305,6 +305,7 @@ export default defineComponent({
     position="bottom"
     :lock-scroll="lockScroll"
     :round="round"
+    :safe-area-inset-bottom="safeAreaInsetBottom"
     @close="close"
     @click-overlay="clickOverlay"
     @open="closeWay = 'self'"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

address组件未设置NutPopup的safe-area-inset-bottom，导致不能开启 iphone 系列全面屏底部安全区适配

